### PR TITLE
Add a target option

### DIFF
--- a/cmd/check_graphite/main.go
+++ b/cmd/check_graphite/main.go
@@ -13,6 +13,7 @@ func main() {
 	p := nagios.NewPlugin("gaphite-data", fs)
 	p.StringFlag("graphite", "", "Graphite render URL: http://localhost/graphite/render/")
 	p.StringFlag("metric", "", "Target metric name")
+	p.StringFlag("target", "", "The target to search for in output.  Leave black and it will look for metric.")
 	p.StringFlag("username", "", "Username for basic auth")
 	p.StringFlag("password", "", "Password for basic auth")
 	flag.Parse()
@@ -24,8 +25,13 @@ func main() {
 	}
 
 	metric := p.OptRequiredString("metric")
+	target, _ := p.OptString("target")
 	username, _ := p.OptString("username")
 	password, _ := p.OptString("password")
+
+	if target == "" {
+		target = metric
+	}
 
 	v := url.Query()
 	v.Add("format", "json")
@@ -56,7 +62,7 @@ func main() {
 		p.Fatalf("got non 200 http status from graphite: %d", resp.StatusCode)
 	}
 
-	value, err := parseGraphiteResponse(resp.Body, metric)
+	value, err := parseGraphiteResponse(resp.Body, target)
 	if err != nil {
 		p.Fatal(err)
 	}

--- a/cmd/check_graphite/parser.go
+++ b/cmd/check_graphite/parser.go
@@ -28,7 +28,7 @@ func parseGraphiteResponse(r io.Reader, metric string) (float64, error) {
 
 	err = json.Unmarshal(body, &targets)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	for _, v := range targets {


### PR DESCRIPTION
So if you do a metric with a wildcard
`telegraf.metafarm-singlebox.client1_example_com.elasticsearch.*.elasticsearch_thread_pool.data_ingest_master.bulk_queue`

The issue is that it will not find a match since the * will get resolved.

Added a option to specify the target to search for.
Example
`aliasByMetric(telegraf.metafarm-singlebox.client1_example_com.elasticsearch.*.elasticsearch_thread_pool.data_ingest_master.bulk_queue)`
Then if I set target = `bulk_queue` it will find the metric

The target if not set will just use the metric like it did before.  So this should not be a breaking change.